### PR TITLE
Update to Webots 6.4.3

### DIFF
--- a/projects/robots/darwin-op/controllers/Makefile
+++ b/projects/robots/darwin-op/controllers/Makefile
@@ -1,9 +1,0 @@
-TARGETS=sample
-
-.PHONY: $(TARGETS)
-
-compil clean:
-	@for X in $(TARGETS); do \
-	  echo $@ing $$X; \
-	  make -s -C $$X $@ ; \
-	done

--- a/projects/robots/darwin-op/controllers/sample/Makefile
+++ b/projects/robots/darwin-op/controllers/sample/Makefile
@@ -42,6 +42,7 @@
 RESOURCES_PATH = $(WEBOTS_HOME)/resources/projects/robots/darwin-op
 CFLAGS = -I"$(RESOURCES_PATH)/include"
 LIBRARIES = "$(RESOURCES_PATH)/lib/managers.a"
+LINK_DEPENDENCIES = $(RESOURCES_PATH)/lib/managers.a
 CPP_SOURCES = main.cpp Sample.cpp
 
 ### Do not modify: this includes Webots global Makefile.include


### PR DESCRIPTION
In Webots 6.4.3, the main Makefile allows to manage better the dependencies on external files.
The present modification allows to take the advantage of this improvement to manage better the dependency on the managers.a static library.
