### PR TITLE
Fixed module camera

### DIFF
--- a/resources/projects/robots/darwin-op/transfer/src/Camera.cpp
+++ b/resources/projects/robots/darwin-op/transfer/src/Camera.cpp
@@ -3,71 +3,70 @@
 
 #include <LinuxDARwIn.h>
 
-using namespace webots;
 
-Camera::Camera(const std::string &name, const Robot *robot) :
+::webots::Camera::Camera(const std::string &name, const Robot *robot) :
   Device(name, robot),
   mImage(NULL)
 {
 }
 
-Camera::~Camera() {
+::webots::Camera::~Camera() {
   disable();
 }
 
-void Camera::enable(int ms) {
+void ::webots::Camera::enable(int ms) {
   disable();
   ::Robot::LinuxCamera::GetInstance()->Initialize(0);
   ::Robot::LinuxCamera::GetInstance()->SetCameraSettings(::Robot::CameraSettings());
   mImage = (unsigned char *) malloc (3*getWidth()*getHeight());
 }
 
-void Camera::disable() {
+void ::webots::Camera::disable() {
   if (mImage) {
     free (mImage);
     mImage = NULL;
   }
 }
 
-const unsigned char *Camera::getImage() const {
+const unsigned char *::webots::Camera::getImage() const {
   ::Robot::LinuxCamera::GetInstance()->CaptureFrame();
   memcpy(mImage, ::Robot::LinuxCamera::GetInstance()->fbuffer->m_RGBFrame->m_ImageData, ::Robot::LinuxCamera::GetInstance()->fbuffer->m_RGBFrame->m_ImageSize);
   return mImage;
 }
 
-int Camera::getWidth() const {
+int ::webots::Camera::getWidth() const {
   return 320;
 }
 
-int Camera::getHeight() const {
+int ::webots::Camera::getHeight() const {
   return 240;
 }
 
-double Camera::getFov() const {
+double ::webots::Camera::getFov() const {
   return 1.0472;
 }
 
-int Camera::getType() const {
+int ::webots::Camera::getType() const {
   return 'c';
 }
 
-double Camera::getNear() const {
+double ::webots::Camera::getNear() const {
   return 0.0;
 }
 
-unsigned char Camera::imageGetRed(const unsigned char *image, int width, int x, int y) {
+unsigned char ::webots::Camera::imageGetRed(const unsigned char *image, int width, int x, int y) {
   return image[3*(y*width + x)];
 }
 
-unsigned char Camera::imageGetGreen(const unsigned char *image, int width, int x, int y) {
+unsigned char ::webots::Camera::imageGetGreen(const unsigned char *image, int width, int x, int y) {
   return image[3*(y*width + x) + 1];
 }
 
-unsigned char Camera::imageGetBlue(const unsigned char *image, int width, int x, int y) {
+unsigned char ::webots::Camera::imageGetBlue(const unsigned char *image, int width, int x, int y) {
   return image[3*(y*width + x) + 2];
 }
 
-unsigned char Camera::imageGetGrey(const unsigned char *image, int width, int x, int y) {
+unsigned char ::webots::Camera::imageGetGrey(const unsigned char *image, int width, int x, int y) {
   return image[3*(y*width + x)] / 3 + image[3*(y*width + x) + 1] / 3  + image[3*(y*width + x) + 2] / 3;
 }
 

--- a/resources/projects/robots/darwin-op/transfer/src/Camera.cpp
+++ b/resources/projects/robots/darwin-op/transfer/src/Camera.cpp
@@ -43,7 +43,7 @@ int ::webots::Camera::getHeight() const {
 }
 
 double ::webots::Camera::getFov() const {
-  return 1.0472;
+  return 1.0123;
 }
 
 int ::webots::Camera::getType() const {


### PR DESCRIPTION
Fixed the problem with the namespace, do not use 'using namespace webots;' anymore.
Changed the value returned for the field of view.
