### PR TITLE
Fixed MotionManager bug MotionFile

### DIFF
--- a/resources/projects/robots/darwin-op/src/managers/DARwInOPMotionManager.cpp
+++ b/resources/projects/robots/darwin-op/src/managers/DARwInOPMotionManager.cpp
@@ -53,9 +53,9 @@ DARwInOPMotionManager::DARwInOPMotionManager(webots::Robot *robot) :
   }
 
   if(0 < firm_ver && firm_ver < 27)
-    filename = DARwInOPDirectoryManager::getDataDirectory() + "motion_4096.bin";
-  else if (27 <= firm_ver)
     filename = DARwInOPDirectoryManager::getDataDirectory() + "motion_1024.bin";
+  else if (27 <= firm_ver)
+    filename = DARwInOPDirectoryManager::getDataDirectory() + "motion_4096.bin";
   else {
     fprintf(stderr, "The firmware version of Dynamixel ID %d is corrupted.\n", JointData::ID_HEAD_PAN);
     mCorrectlyInitialized = false;


### PR DESCRIPTION
The file-motion loaded was not the right one, so the movements were totally wrong.
This as been corrected by switching "motion_4096.bin" and "motion_1024.bin".
