### PR TITLE
Updated initialisation of the LinuxMotionTimer

### DIFF
--- a/resources/projects/robots/darwin-op/transfer/src/Robot.cpp
+++ b/resources/projects/robots/darwin-op/transfer/src/Robot.cpp
@@ -167,5 +167,6 @@ void webots::Robot::initDarwinOP() {
   }
   
   ::Robot::MotionManager::GetInstance()->Initialize(mCM730);
-  ::Robot::LinuxMotionTimer::Initialize(::Robot::MotionManager::GetInstance());
+  ::Robot::LinuxMotionTimer *motion_timer = new ::Robot::LinuxMotionTimer(::Robot::MotionManager::GetInstance());
+  motion_timer->Start();
 }


### PR DESCRIPTION
The method LinuxMotionTimer::Initialize do not exist anymore in the new version of the Framework (even if in the doc it is always present).
