### PR TITLE
Added class DARwInOPMotionTimerManager

### DIFF
--- a/projects/robots/darwin-op/controllers/sample/Makefile.darwin-op
+++ b/projects/robots/darwin-op/controllers/sample/Makefile.darwin-op
@@ -24,6 +24,7 @@ CXX_SOURCES = \
   Sample.cpp \
   $(WEBOTS_DARWINOP_PROJECT_ROOT)/src/managers/DARwInOPDirectoryManager.cpp \
   $(WEBOTS_DARWINOP_PROJECT_ROOT)/src/managers/DARwInOPMotionManager.cpp \
+  $(WEBOTS_DARWINOP_PROJECT_ROOT)/src/managers/DARwInOPMotionTimerManager.cpp \
   $(WEBOTS_DARWINOP_PROJECT_ROOT)/src/managers/DARwInOPGaitManager.cpp
 
 # -------------------------------------------------------------

--- a/resources/projects/robots/darwin-op/include/managers/DARwInOPMotionTimerManager.hpp
+++ b/resources/projects/robots/darwin-op/include/managers/DARwInOPMotionTimerManager.hpp
@@ -1,0 +1,29 @@
+// File:          DARwInOPMotionTimerManager.hpp
+// Date:          16th of October 2012
+// Description:   Facade between webots and the darwin-op framework
+//                allowing to to start the LinuxMotionTimer in order
+//                to play the Robotis motion files and the walking algorithm.
+// Author:        fabien.rohrer@cyberbotics.com
+
+#ifndef DARWINOP_MOTION_TIMER_MANAGER_HPP
+#define DARWINOP_MOTION_TIMER_MANAGER_HPP
+
+namespace Robot {
+  class LinuxMotionTimer;
+}
+
+namespace managers {
+  using namespace Robot;
+  class DARwInOPMotionTimerManager {
+    public:
+                       DARwInOPMotionTimerManager();
+      virtual         ~DARwInOPMotionTimerManager();
+      static void      MotionTimerInit();
+
+    private:
+      static bool      mStarted;
+
+  };
+}
+
+#endif

--- a/resources/projects/robots/darwin-op/include/managers/DARwInOPMotionTimerManager.hpp
+++ b/resources/projects/robots/darwin-op/include/managers/DARwInOPMotionTimerManager.hpp
@@ -3,7 +3,7 @@
 // Description:   Facade between webots and the darwin-op framework
 //                allowing to to start the LinuxMotionTimer in order
 //                to play the Robotis motion files and the walking algorithm.
-// Author:        fabien.rohrer@cyberbotics.com
+// Author:        david.mansolino@epfl.ch
 
 #ifndef DARWINOP_MOTION_TIMER_MANAGER_HPP
 #define DARWINOP_MOTION_TIMER_MANAGER_HPP

--- a/resources/projects/robots/darwin-op/lib/Makefile.darwin-op
+++ b/resources/projects/robots/darwin-op/lib/Makefile.darwin-op
@@ -1,6 +1,7 @@
 MANAGERS_SOURCES_PATH = ../src/managers
 MANAGERS_INCLUDE_PATH = ../include
 DARWIN_FRAMEWORK_PATH = /darwin/Framework
+DARWIN_LINUX_PATH = /darwin/Linux
 WEBOTS_INCLUDE_PATH = ../transfer/include/
 TARGET = managers.a
 
@@ -12,9 +13,11 @@ CXX_SOURCES = \
   $(DARWIN_FRAMEWORK_PATH)/src/motion/MotionStatus.cpp \
   $(DARWIN_FRAMEWORK_PATH)/src/motion/modules/Action.cpp \
   $(DARWIN_FRAMEWORK_PATH)/src/motion/modules/Walking.cpp \
+  $(DARWIN_LINUX_PATH)/build/LinuxMotionTimer.cpp \
   $(MANAGERS_SOURCES_PATH)/DARwInOPDirectoryManager.cpp \
   $(MANAGERS_SOURCES_PATH)/DARwInOPMotionManager.cpp \
-  $(MANAGERS_SOURCES_PATH)/DARwInOPGaitManager.cpp
+  $(MANAGERS_SOURCES_PATH)/DARwInOPGaitManager.cpp \
+  $(MANAGERS_SOURCES_PATH)/DARwInOPMotionTimerManager.cpp
 C_SOURCES = \
   $(DARWIN_FRAMEWORK_PATH)/src/minIni/minIni.c
 SOURCES = $(C_SOURCES) $(CXX_SOURCES)
@@ -25,8 +28,8 @@ AR          = ar cr
 CC        = gcc
 CXX       = g++
 OBJECTS   = $(notdir $(CXX_SOURCES:.cpp=.o) $(C_SOURCES:.c=.o))
-CFLAGS   += -c -O2 -Wall -DWEBOTS -I$(DARWIN_FRAMEWORK_PATH)/include -I$(MANAGERS_INCLUDE_PATH) -I$(WEBOTS_INCLUDE_PATH)
-CXXFLAGS += -c -O2 -Wall -DWEBOTS -I$(DARWIN_FRAMEWORK_PATH)/include -I$(MANAGERS_INCLUDE_PATH) -I$(WEBOTS_INCLUDE_PATH)
+CFLAGS   += -c -O2 -Wall -DWEBOTS -I$(DARWIN_FRAMEWORK_PATH)/include -I$(DARWIN_LINUX_PATH)/include -I$(MANAGERS_INCLUDE_PATH) -I$(WEBOTS_INCLUDE_PATH)
+CXXFLAGS += -c -O2 -Wall -DWEBOTS -I$(DARWIN_FRAMEWORK_PATH)/include -I$(DARWIN_LINUX_PATH)/include -I$(MANAGERS_INCLUDE_PATH) -I$(WEBOTS_INCLUDE_PATH)
 DEPENDENCIES = $(OBJECTS:.o=.d)
 
 .PHONY: clean compil

--- a/resources/projects/robots/darwin-op/src/managers/DARwInOPMotionTimerManager.cpp
+++ b/resources/projects/robots/darwin-op/src/managers/DARwInOPMotionTimerManager.cpp
@@ -1,0 +1,27 @@
+#include <managers/DARwInOPMotionTimerManager.hpp>
+
+#include <webots/Robot.hpp>
+
+#include <LinuxMotionTimer.h>
+#include <MotionManager.h>
+
+using namespace Robot;
+using namespace managers;
+using namespace webots;
+using namespace std;
+
+DARwInOPMotionTimerManager::DARwInOPMotionTimerManager() {
+}
+
+void DARwInOPMotionTimerManager::MotionTimerInit() {
+  if(!mStarted) {
+    LinuxMotionTimer *motion_timer = new LinuxMotionTimer(MotionManager::GetInstance());
+    motion_timer->Start();
+    mStarted = true;
+  }
+}
+
+DARwInOPMotionTimerManager::~DARwInOPMotionTimerManager() {
+}
+
+bool DARwInOPMotionTimerManager::mStarted = false;


### PR DESCRIPTION
This class is used to start the LinuxMotionTimer, which is nedded for the gait and motion managers.
Furthermore it ensures that it is activated only one time.
