### PR TITLE
Fixed compilation issue

### DIFF
--- a/projects/robots/darwin-op/controllers/sample/Sample.hpp
+++ b/projects/robots/darwin-op/controllers/sample/Sample.hpp
@@ -16,8 +16,6 @@ namespace managers {
   class DARwInOPGaitManager;
 }
 
-using namespace Robot;
-
 namespace webots {
   class Servo;
   class LED;


### PR DESCRIPTION
"using namespace" should not be put into headers.
Moreover this fix a compilation issue:

In file included from main.cpp:6:
./Sample.hpp:19:17: error: expected namespace name
using namespace Robot;
