### PR TITLE
Modified sensors updatement method

### DIFF
--- a/resources/projects/robots/darwin-op/transfer/include/webots/Accelerometer.hpp
+++ b/resources/projects/robots/darwin-op/transfer/include/webots/Accelerometer.hpp
@@ -9,6 +9,7 @@
 #ifndef ACCELEROMETER_HPP
 #define ACCELEROMETER_HPP
 
+#include <webots/Robot.hpp>
 #include <webots/Device.hpp>
 
 namespace webots {
@@ -19,6 +20,12 @@ namespace webots {
       virtual void  enable(int ms);
       virtual void  disable();
       const double *getValues() const;
+
+    private:
+      double        mValues[3];
+      void          setValues(const int *integerValues);
+    
+    friend int Robot::step(int ms);
   };
 }
 

--- a/resources/projects/robots/darwin-op/transfer/include/webots/Gyro.hpp
+++ b/resources/projects/robots/darwin-op/transfer/include/webots/Gyro.hpp
@@ -9,6 +9,7 @@
 #ifndef GYRO_HPP
 #define GYRO_HPP
 
+#include <webots/Robot.hpp>
 #include <webots/Device.hpp>
 
 namespace webots {
@@ -19,6 +20,12 @@ namespace webots {
       virtual void  enable(int ms);
       virtual void  disable();
       const double *getValues() const;
+
+    private:
+      double        mValues[3];
+      void          setValues(const int *integerValues);
+    
+    friend int Robot::step(int ms);
   };
 }
 

--- a/resources/projects/robots/darwin-op/transfer/src/Accelerometer.cpp
+++ b/resources/projects/robots/darwin-op/transfer/src/Accelerometer.cpp
@@ -6,11 +6,11 @@
 using namespace webots;
 using namespace Robot;
 
-static double values[3];
-
 Accelerometer::Accelerometer(const std::string &name, const Robot *robot) :
   Device(name, robot)
 {
+  for (int i=0; i<3; i++)
+    mValues[i] = 512;
 }
 
 Accelerometer::~Accelerometer() {
@@ -23,15 +23,10 @@ void Accelerometer::disable() {
 }
 
 const double *Accelerometer::getValues() const {
-  CM730 *cm730 = getRobot()->getCM730();
-  
-  int integerValues[3];
-  cm730->ReadWord(CM730::ID_CM, CM730::P_ACCEL_X_L, &integerValues[0], 0);
-  cm730->ReadWord(CM730::ID_CM, CM730::P_ACCEL_Y_L, &integerValues[1], 0);
-  cm730->ReadWord(CM730::ID_CM, CM730::P_ACCEL_Z_L, &integerValues[2], 0);
-  
+  return mValues;
+}
+
+void Accelerometer::setValues(const int *integerValues) {
   for (int i=0; i<3; i++)
-    values[i] = integerValues[i];
-  
-  return values;
+    mValues[i] = integerValues[i];
 }

--- a/resources/projects/robots/darwin-op/transfer/src/Accelerometer.cpp
+++ b/resources/projects/robots/darwin-op/transfer/src/Accelerometer.cpp
@@ -10,7 +10,7 @@ Accelerometer::Accelerometer(const std::string &name, const Robot *robot) :
   Device(name, robot)
 {
   for (int i=0; i<3; i++)
-    mValues[i] = 512;
+    mValues[i] = 512;  // 512 = central value -> no acceleration
 }
 
 Accelerometer::~Accelerometer() {

--- a/resources/projects/robots/darwin-op/transfer/src/Gyro.cpp
+++ b/resources/projects/robots/darwin-op/transfer/src/Gyro.cpp
@@ -10,7 +10,7 @@ Gyro::Gyro(const std::string &name, const Robot *robot) :
   Device(name, robot)
 {
   for (int i=0; i<3; i++)
-    mValues[i] = 512;  // 512 = centrale value -> no rotation
+    mValues[i] = 512;  // 512 = central value -> no rotation
 }
 
 Gyro::~Gyro() {

--- a/resources/projects/robots/darwin-op/transfer/src/Gyro.cpp
+++ b/resources/projects/robots/darwin-op/transfer/src/Gyro.cpp
@@ -10,7 +10,7 @@ Gyro::Gyro(const std::string &name, const Robot *robot) :
   Device(name, robot)
 {
   for (int i=0; i<3; i++)
-    mValues[i] = 512;
+    mValues[i] = 512;  // 512 = centrale value -> no rotation
 }
 
 Gyro::~Gyro() {

--- a/resources/projects/robots/darwin-op/transfer/src/Gyro.cpp
+++ b/resources/projects/robots/darwin-op/transfer/src/Gyro.cpp
@@ -6,11 +6,11 @@
 using namespace webots;
 using namespace Robot;
 
-static double values[3];
-
 Gyro::Gyro(const std::string &name, const Robot *robot) :
   Device(name, robot)
 {
+  for (int i=0; i<3; i++)
+    mValues[i] = 512;
 }
 
 Gyro::~Gyro() {
@@ -23,15 +23,10 @@ void Gyro::disable() {
 }
 
 const double *Gyro::getValues() const {
-  CM730 *cm730 = getRobot()->getCM730();
-  
-  int integerValues[3];
-  cm730->ReadWord(CM730::ID_CM, CM730::P_GYRO_X_L, &integerValues[0], 0);
-  cm730->ReadWord(CM730::ID_CM, CM730::P_GYRO_Y_L, &integerValues[1], 0);
-  cm730->ReadWord(CM730::ID_CM, CM730::P_GYRO_Z_L, &integerValues[2], 0);
-  
+  return mValues;
+}
+
+void Gyro::setValues(const int *integerValues) {
   for (int i=0; i<3; i++)
-    values[i] = integerValues[i];
-  
-  return values;
+    mValues[i] = integerValues[i];
 }


### PR DESCRIPTION
All the sensors are now update in the robot::step in only one reading, and the values are stored in the corresponding class.
This permit to do only one reading instead of 6 (3 for Acc and 3 for Gyro), and to have a good gain of time. Reading of the accelerometer and gyroscop take now 2-3ms instead of 10-18ms before !
