### PR TITLE
Fixed bugs with the Motion manager in simulation

### DIFF
--- a/resources/projects/robots/darwin-op/src/managers/DARwInOPMotionManager.cpp
+++ b/resources/projects/robots/darwin-op/src/managers/DARwInOPMotionManager.cpp
@@ -111,11 +111,13 @@ void DARwInOPMotionManager::playPage(int id) {
   Action::PAGE page;
   if (mAction->LoadPage(id, &page)) {
     // cout << "Play motion " << setw(2) << id << ": " << page.header.name << endl;
-    for(int j=0; j<page.header.stepnum; j++) {
-       for(int k=0; k<DMM_NSERVOS; k++)
-         mTargetPositions[k] = valueToPosition(page.step[j].position[k+1]);
-       achieveTarget(8*page.step[j].time);
-       wait(8*page.step[j].pause);
+    for(int i=0; i<page.header.repeat; i++) {
+      for(int j=0; j<page.header.stepnum; j++) {
+         for(int k=0; k<DMM_NSERVOS; k++)
+           mTargetPositions[k] = valueToPosition(page.step[j].position[k+1]);
+         achieveTarget(8*page.step[j].time);
+         wait(8*page.step[j].pause);
+      }
     }
   }
   else

--- a/resources/projects/robots/darwin-op/src/managers/DARwInOPMotionManager.cpp
+++ b/resources/projects/robots/darwin-op/src/managers/DARwInOPMotionManager.cpp
@@ -119,6 +119,8 @@ void DARwInOPMotionManager::playPage(int id) {
          wait(8*page.step[j].pause);
       }
     }
+    if(page.header.next != 0)
+      playPage(page.header.next);
   }
   else
     cerr << "Cannot load the page" << endl;


### PR DESCRIPTION
Fixed two bugs with the Motion manager in simulation :
1) When asking to play a page the page was played, but if this page needed to be played several times, this was not done -> corrected.
2) When asking to play a page the page was played, but if this page was linked to another that need to be played after this one, the next page was not played -> corrected.
