### PR TITLE
Fixed initial rotation

### DIFF
--- a/projects/robots/darwin-op/worlds/darwin-op.wbt
+++ b/projects/robots/darwin-op/worlds/darwin-op.wbt
@@ -47,7 +47,7 @@ DEF BLUE_GOAL Goal {
 DEF BALL Ball {
 }
 DARwInOP {
-  translation -0.413972 0.245 -0.396853
-  rotation 0 1 0 1.0562
+  translation -0.413972 0.236 -0.396853
+  rotation 0.1023 0.9930 -0.0596 1.06235
   controller "sample"
 }

--- a/projects/robots/darwin-op/worlds/symmetry.wbt
+++ b/projects/robots/darwin-op/worlds/symmetry.wbt
@@ -41,12 +41,13 @@ DirectionalLight {
 Table {
 }
 DARwInOP {
-  translation 0 0.985 0
-  rotation 0 1 0 1.5798
+  translation 0 0.976 0
+  rotation 0.0593 0.9964 -0.0599 1.58336
   controller "symmetry"
   cameraPixelSize 0
   cameraWidth 360
   cameraHeight 240
+  selfCollision TRUE
 }
 Floor {
   size 11 14


### PR DESCRIPTION
Modified initial rotation in the two examples, in order to suppress the initial oscillations.
In the example symmetry, enabled the self collision by default.
