### PR TITLE
Fixed wrong macro test

### DIFF
--- a/resources/projects/robots/darwin-op/darwin/Framework/src/motion/modules/Action.cpp
+++ b/resources/projects/robots/darwin-op/darwin/Framework/src/motion/modules/Action.cpp
@@ -102,8 +102,9 @@ bool Action::LoadFile( char* filename )
 {
 	FILE *action = fopen( filename, "r+b" );
 
+#ifdef WEBOTS
 	// Olivier.Michel@cyberbotics.com added the following line to allow opening a readonly file located in the Webots installation directory.
-#ifndef WEBOTS
+  // This is mainly problematic on Windows
 	if( action == 0 ) action = fopen( filename, "rb" );
 #endif
 


### PR DESCRIPTION
The WEBOTS macro test was inverted causing issues in the Webots release on Windows
