### PR TITLE
Corrected center of mass of the body in the proto.

### DIFF
--- a/projects/robots/darwin-op/worlds/darwin-op.wbt
+++ b/projects/robots/darwin-op/worlds/darwin-op.wbt
@@ -45,6 +45,7 @@ DEF BLUE_GOAL Goal {
   postColor 0.152941 0.505882 0.733333
 }
 DEF BALL Ball {
+  translation 0 0.0325 -0.01
 }
 DARwInOP {
   translation -0.413972 0.236 -0.396853

--- a/resources/projects/robots/darwin-op/protos/DARwInOP.proto
+++ b/resources/projects/robots/darwin-op/protos/DARwInOP.proto
@@ -5570,7 +5570,7 @@ Robot {
   physics Physics {
     density -1
     mass 0.975599
-    centerOfMass 0.000 -0.08 -0.05
+    centerOfMass -0.003 -0.03944 -0.01966
     inertiaMatrix [3.1081800e-03 6.3787776e-03 5.3316425e-03, -2.5460189e-04 2.0318174e-03 1.6417863e-04]
   }
   controller IS controller


### PR DESCRIPTION
Corrected center of mass of the body in the proto to be in agreement with the doc.
The ball in example 'sample' has also been moved a very little bit in order to not miss the first shoot.
