### PR TITLE
Corrected link between Head and Eye LED and added the two backled representing them

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,8 @@ Webots 7.0.4
     Added Vision Manager in order to use the main image processing tools of the Framework in simulation
     Added example Visual Tracking
     Updated example Sample to use Manager Vision
+    Corrected wrong link between Head and Eye LED
+    Added the two backLED representations of Head and Eye LED (these backLED are not controllable)
 
   Cross-Compilation:
     
@@ -13,11 +15,11 @@ Webots 7.0.4
 
 Webots 7.0.3
 
-Released on December
+Released on December 6th, 2012 (revision 12573) 
 
   Simulation :
 
-    Corrected center of mass of LegLowerL and LegLowerR
+    Corrected center of mass of LegLowerL and LegLowerR (thanks to Chase)
     Added field staticFriction and adapted field dampingConstant for each servos
     Added a warning if the MotionManager is used without having enabled all the servos position and auto enable them
 

--- a/resources/projects/robots/darwin-op/protos/DARwInOP.proto
+++ b/resources/projects/robots/darwin-op/protos/DARwInOP.proto
@@ -1159,7 +1159,7 @@ Robot {
               children [
                 DEF DEyeLEDShape Shape {
                   appearance Appearance {
-                    material DEF DLEDMaterial Material {
+                    material DEF DEyeLEDMaterial Material {
                       ambientIntensity 0
                       diffuseColor 0.7 0.7 0.7
                     }
@@ -1275,7 +1275,10 @@ Robot {
               children [
                 DEF DHeadLEDShape Shape {
                   appearance Appearance {
-                    material USE DLEDMaterial
+                    material DEF DHeadLEDMaterial Material {
+                      ambientIntensity 0
+                      diffuseColor 0.7 0.7 0.7
+                    }
                   }
                   geometry IndexedFaceSet {
                     coord Coordinate {
@@ -5545,6 +5548,32 @@ Robot {
         inertiaMatrix [9.7758165e-06 1.0511104e-05 5.4767980e-06, -1.6911839e-06 4.5174329e-07 3.3406955e-07]
       }
       maxForce 2.5
+    }
+    DEF DHeadBackLED Transform {
+      translation -0.01 -0.01 -0.076
+      children [
+        Shape {
+          appearance Appearance {
+            material USE DHeadLEDMaterial
+          }
+          geometry Box {
+            size 0.002 0.005 0.002
+          }
+        }
+      ]
+    }
+    DEF DEyeBackLED Transform {
+      translation -0.015 -0.01 -0.076
+      children [
+        Shape {
+          appearance Appearance {
+            material USE DEyeLEDMaterial
+          }
+          geometry Box {
+            size 0.002 0.005 0.002
+          }
+        }
+      ]
     }
   ]
   boundingObject Group {


### PR DESCRIPTION
Corrected link between Head and Eye LED and added the two backled representing them in the PROTO.
Updated Changelog.
