### PR TITLE
Improved start of the controller in cross-compilation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,8 @@ Webots 7.0.4
   Cross-Compilation:
     
     Vision Manager is also available on the real robot
+    Improved start of the controller, servo movements smoother at startup
+    Added LED indications (red : robot is initializing / green : robot is ready, controller will start)
 
 
 Webots 7.0.3

--- a/resources/projects/robots/darwin-op/transfer/src/Robot.cpp
+++ b/resources/projects/robots/darwin-op/transfer/src/Robot.cpp
@@ -55,6 +55,10 @@ webots::Robot::Robot() {
   mCM730->SyncWrite(::Robot::MX28::P_GOAL_POSITION_L, msgLength, changed_servos , param);
   usleep(2000000); // wait a moment to reach start position
 
+  // Switch LED to GREEN
+  mCM730->WriteWord(::Robot::CM730::ID_CM, ::Robot::CM730::P_LED_HEAD_L, 1984, 0);
+  mCM730->WriteWord(::Robot::CM730::ID_CM, ::Robot::CM730::P_LED_EYE_L, 1984, 0);
+
 }
 
 webots::Robot::~Robot() {
@@ -282,6 +286,10 @@ void webots::Robot::initDarwinOP() {
   }
   
   ::Robot::MotionManager::GetInstance()->Initialize(mCM730);
+
+  // Switch LED to RED
+  mCM730->WriteWord(::Robot::CM730::ID_CM, ::Robot::CM730::P_LED_HEAD_L, 63, 0);
+  mCM730->WriteWord(::Robot::CM730::ID_CM, ::Robot::CM730::P_LED_EYE_L, 63, 0);
 }
 
 void webots::Robot::LoadINISettings(minIni* ini, const std::string &section) {


### PR DESCRIPTION
The servos go now slowly to the start position.
Added the update of the joint manager in order to make smother the transition to the motion manager.
Added indication with the two RGB LED at the start of the controller in cross-compilation : red : 'robot is initializing / green : robot is ready, controller will start'.
