### PR TITLE
Updated target in makefile for cross-compilation

### DIFF
--- a/projects/robots/darwin-op/controllers/visual_tracking/Makefile.darwin-op
+++ b/projects/robots/darwin-op/controllers/visual_tracking/Makefile.darwin-op
@@ -12,7 +12,7 @@
 # TO MODIFY:
 
 # name of the binary to generate
-TARGET = visualTracking
+TARGET = visual_tracking
 
 # pathes
 DARWINOP_ROOT = /darwin


### PR DESCRIPTION
Updated target in projects/robots/darwin-op/controllers/visual_tracking/Makefile.darwin-op used for cross-compilation.
