### PR TITLE
Corrected small bug in LinuxCamera.cpp

### DIFF
--- a/resources/projects/robots/darwin-op/darwin/Linux/build/LinuxCamera.cpp
+++ b/resources/projects/robots/darwin-op/darwin/Linux/build/LinuxCamera.cpp
@@ -482,7 +482,7 @@ int LinuxCamera::ReadFrameWb()
             int r, g, b;
             int y, u, v;
 
-            if(!z)
+            if(z)
                 y = yuyv[-3] << 8;
             else
                 y = yuyv[-1] << 8;


### PR DESCRIPTION
I found this bug when working on the remote-control tool.
(It did not change anything to the result of the vision manager, but the image is now better)
