### PR TITLE
Corrected wrong link between the BackLeds

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,13 @@
+Webots 7.1.X
+
+  Simulation :
+
+    Corrected wrong link between the LEDS: BackLedRed, BackLedGreen and BackLedBlue.
+
+
 Webots 7.1.0
 
-Released on January XXth, 2012 (revision XXXXX) 
+Released on January 18th, 2012 (revision 13099) 
 
   Simulation :
 

--- a/resources/projects/robots/darwin-op/protos/DARwInOP.proto
+++ b/resources/projects/robots/darwin-op/protos/DARwInOP.proto
@@ -8,7 +8,7 @@
 #- camera
 #- realistic physics
 #
-# More info here: http://darwin-op.springnote.com
+# More info here: http://support.robotis.com/ko/product/darwin-op.htm
 #
 # Modeled by fabien.rohrer@cyberbotics.com
 

--- a/resources/projects/robots/darwin-op/protos/DARwInOP.proto
+++ b/resources/projects/robots/darwin-op/protos/DARwInOP.proto
@@ -468,7 +468,7 @@ Robot {
       color [0 1 0]
       name "BackLedGreen"
       children [
-        DEF BackLedShape Shape {
+        Shape {
               appearance Appearance {
                 material Material {
                   ambientIntensity 0.01
@@ -486,7 +486,17 @@ Robot {
       color [0 0 1]
       name "BackLedBlue"
       children [
-        USE BackLedShape
+        Shape {
+              appearance Appearance {
+                material Material {
+                  ambientIntensity 0.01
+                  transparency 0.1
+                }
+              }
+            geometry Box {
+            size 0.002 0.005 0.002
+          }
+        }
       ]
     }
     LED {
@@ -494,7 +504,17 @@ Robot {
       color [1 0 0]
       name "BackLedRed"
       children [
-        USE BackLedShape
+        Shape {
+              appearance Appearance {
+                material Material {
+                  ambientIntensity 0.01
+                  transparency 0.1
+                }
+              }
+            geometry Box {
+            size 0.002 0.005 0.002
+          }
+        }
       ]
     }
     Accelerometer {


### PR DESCRIPTION
Corrected wrong link between the LEDS: BackLedRed, BackLedGreen and BackLedBlue.
Same problem that has already been corrected for Head and Eye Leds.
Updated darwin website in proto description.
