### PR TITLE
World

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,8 @@ Webots 7.1.X
 
   Simulation :
 
-    Corrected wrong link between the LEDS: BackLedRed, BackLedGreen and BackLedBlue.
+    Corrected wrong link between the LEDS: BackLedRed, BackLedGreen and BackLedBlue
+    Set default basicTimeStep to 16ms for each example
 
 
 Webots 7.1.0

--- a/projects/robots/darwin-op/worlds/soccer.wbt
+++ b/projects/robots/darwin-op/worlds/soccer.wbt
@@ -7,7 +7,7 @@ WorldInfo {
     "Date: May 2011"
   ]
   title "Robotis DARwIn-OP"
-  basicTimeStep 8
+  basicTimeStep 16
   displayRefresh 4
 }
 Viewpoint {

--- a/projects/robots/darwin-op/worlds/symmetry.wbt
+++ b/projects/robots/darwin-op/worlds/symmetry.wbt
@@ -7,7 +7,7 @@ WorldInfo {
     "Date: May 2011"
   ]
   title "Robotis DARwIn-OP"
-  basicTimeStep 8
+  basicTimeStep 16
   displayRefresh 4
 }
 Viewpoint {

--- a/projects/robots/darwin-op/worlds/symmetry.wbt
+++ b/projects/robots/darwin-op/worlds/symmetry.wbt
@@ -9,13 +9,6 @@ WorldInfo {
   title "Robotis DARwIn-OP"
   basicTimeStep 8
   displayRefresh 4
-  contactProperties [
-    ContactProperties {
-      material2 "DMetalMaterial"
-      coulombFriction 20
-      bounce 0.3
-    }
-  ]
 }
 Viewpoint {
   orientation -0.162905 0.937794 0.306602 2.21925

--- a/projects/robots/darwin-op/worlds/visual_tracking.wbt
+++ b/projects/robots/darwin-op/worlds/visual_tracking.wbt
@@ -7,7 +7,7 @@ WorldInfo {
     "Date: May 2011"
   ]
   title "Robotis DARwIn-OP"
-  basicTimeStep 8
+  basicTimeStep 16
   displayRefresh 4
 }
 Viewpoint {

--- a/projects/robots/darwin-op/worlds/visual_tracking.wbt
+++ b/projects/robots/darwin-op/worlds/visual_tracking.wbt
@@ -9,13 +9,6 @@ WorldInfo {
   title "Robotis DARwIn-OP"
   basicTimeStep 8
   displayRefresh 4
-  contactProperties [
-    ContactProperties {
-      material2 "DMetalMaterial"
-      coulombFriction 20
-      bounce 0.3
-    }
-  ]
 }
 Viewpoint {
   orientation -0.162905 0.937794 0.306602 2.21925

--- a/projects/robots/darwin-op/worlds/walk.wbt
+++ b/projects/robots/darwin-op/worlds/walk.wbt
@@ -7,7 +7,7 @@ WorldInfo {
     "Date: May 2011"
   ]
   title "Robotis DARwIn-OP"
-  basicTimeStep 8
+  basicTimeStep 16
   displayRefresh 4
 }
 Viewpoint {


### PR DESCRIPTION
Removed usless contactProperties in some world files.

Set basicTimeStep of the world to 16.  
I thought it was already done, this time step is well suited : 
1) The simulation can easily run at a speed of 1 (and even more)
2) This time step is well suited for cross-compilation
3) This time step is also well suited for remote-control
