### PR TITLE
Changed camera refresh time to 2*timeStep in the example

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,7 +4,11 @@ Webots 7.1.X
 
     Corrected wrong link between the LEDS: BackLedRed, BackLedGreen and BackLedBlue
     Set default basicTimeStep to 16ms for each example
+    Increase camera refresh time to 32ms in example 'Soccer' and 'Visual_tracking'
 
+  Cross-Compilation:
+    
+    Added text-to-speech functions in Speaker module
 
 Webots 7.1.0
 

--- a/projects/robots/darwin-op/controllers/soccer/Soccer.cpp
+++ b/projects/robots/darwin-op/controllers/soccer/Soccer.cpp
@@ -37,7 +37,7 @@ Soccer::Soccer():
   mBackLedGreen = getLED("BackLedGreen");
   mBackLedBlue = getLED("BackLedBlue");
   mCamera = getCamera("Camera");
-  mCamera->enable(mTimeStep);
+  mCamera->enable(2*mTimeStep);
   mAccelerometer = getAccelerometer("Accelerometer");
   mAccelerometer->enable(mTimeStep);
   mGyro = getGyro("Gyro");

--- a/projects/robots/darwin-op/controllers/visual_tracking/VisualTracking.cpp
+++ b/projects/robots/darwin-op/controllers/visual_tracking/VisualTracking.cpp
@@ -29,7 +29,7 @@ VisualTracking::VisualTracking():
   mEyeLED = getLED("EyeLed");
   mHeadLED = getLED("HeadLed");
   mCamera = getCamera("Camera");
-  mCamera->enable(mTimeStep);
+  mCamera->enable(2*mTimeStep);
   
   for (int i=0; i<NSERVOS; i++)
     mServos[i] = getServo(servoNames[i]);


### PR DESCRIPTION
This is because camera refresh time on the real robot is 33ms.
This also help in remote-control to keep the speed at 1.0x with high camera resolution.
