### PR TITLE
Corrected ball color in example soccer

### DIFF
--- a/projects/robots/darwin-op/controllers/soccer/Soccer.cpp
+++ b/projects/robots/darwin-op/controllers/soccer/Soccer.cpp
@@ -50,7 +50,7 @@ Soccer::Soccer():
   
   mMotionManager = new DARwInOPMotionManager(this);
   mGaitManager = new DARwInOPGaitManager(this, "config.ini");
-  mVisionManager = new DARwInOPVisionManager(mCamera->getWidth(), mCamera->getHeight(), 42, 20, 50, 45, 0.01, 30);
+  mVisionManager = new DARwInOPVisionManager(mCamera->getWidth(), mCamera->getHeight(), 28, 20, 50, 45, 0.01, 30);
 }
 
 Soccer::~Soccer() {


### PR DESCRIPTION
Corrected ball color in example soccer, the robot was sometimes attract by the goal instead of the ball.
