### PR TITLE
Minor code improvement

### DIFF
--- a/resources/projects/robots/darwin-op/plugins/robot_windows/darwin-op_window/Transfer.cpp
+++ b/resources/projects/robots/darwin-op/plugins/robot_windows/darwin-op_window/Transfer.cpp
@@ -22,7 +22,8 @@
 
 using namespace webotsQtUtils;
 
-Transfer::Transfer()
+Transfer::Transfer(QWidget *parent):
+  QScrollArea(parent)
 {
   setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   setMinimumHeight(520);

--- a/resources/projects/robots/darwin-op/plugins/robot_windows/darwin-op_window/Transfer.hpp
+++ b/resources/projects/robots/darwin-op/plugins/robot_windows/darwin-op_window/Transfer.hpp
@@ -21,7 +21,7 @@ class Transfer : public QScrollArea, public SSH
   Q_OBJECT
 	
 public:
-  Transfer();
+  Transfer(QWidget *parent = 0);
   virtual ~Transfer();
 
 public slots:

--- a/resources/projects/robots/darwin-op/plugins/robot_windows/darwin-op_window/Viewer.cpp
+++ b/resources/projects/robots/darwin-op/plugins/robot_windows/darwin-op_window/Viewer.cpp
@@ -6,7 +6,7 @@ using namespace webotsQtUtils;
 Viewer::Viewer() :
   GenericWindow()
 {
-  mTabWidget->addTab(new Transfer, QString("Transfer"));
+  mTabWidget->addTab(new Transfer(this), "Transfer");
 }
 
 Viewer::~Viewer() {

--- a/resources/projects/robots/darwin-op/plugins/robot_windows/darwin-op_window/Viewer.hpp
+++ b/resources/projects/robots/darwin-op/plugins/robot_windows/darwin-op_window/Viewer.hpp
@@ -17,8 +17,6 @@ class Viewer : public webotsQtUtils::GenericWindow
     Viewer();
     virtual ~Viewer();
 
-  protected:
-
 };
 
 #endif


### PR DESCRIPTION
-> Adding parent widget managment to Transfer is useful to cleanup cleanly the code
-> Cast from const char\* to QString is impicit
-> Empty protected statement is useless
