### PR TITLE
Removed warning when toggling from remote-control mode to simulation mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,16 +3,21 @@ Webots 7.X.X
   Added the possibility to use MotionManager step-by-step (both for simulation and cross-compilation)
 
   Simulation :
-
     
 
   Cross-Compilation:
-    
+    Minors debug when cross-compiling from the robot window on Windows (checkbox 'make default controller' now toogle correctly, message windows are not hidden behind the robot window anymore)
+
+
+  Remote-control:
+    Fixed problem of crash of the remote-server when sending command to servos who doesn't exist
+    Fixed problem of crash of the robot window when aborting start of remote-control   
+    Fixed problem of led switching off when stopping the controller
     
 
 Webots 7.1.1
 
-Released on March XXth, 2013 (revision XXXXX) 
+Released on March 7th, 2013 (revision 13751) 
 
   Added remote-control
   Added custom robot-window which allows to install Webots API on the robot, start remote-control and cross-compile easily

--- a/resources/projects/robots/darwin-op/protos/DARwInOP.proto
+++ b/resources/projects/robots/darwin-op/protos/DARwInOP.proto
@@ -1174,6 +1174,8 @@ Robot {
               width IS cameraWidth
               height IS cameraHeight
               pixelSize IS cameraPixelSize
+              zoom CameraZoom {
+              }
             }
             DEF DEyeLED LED {
               rotation 1 0 0 0


### PR DESCRIPTION
-Added empty node CameraZoom to the camera in the proto in order to avoid a warning (WARNING: DARwInOP (PROTO) > DEF DNeck Servo > DEF DHead Servo > Camera: wb_camera_set_fov() cannot be applied to this camera: missing 'zoom'.) when toggling from remote-control mode to simulation mode
-Updated changelog.
