### PR TITLE
Corrected problem of controllers compilation errors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+Webots 7.1.X
+
+Released ...
+
+  Simulation :
+
+  Cross-Compilation:
+    Corrected problem of controllers compilation errors if the time of the robot and of the computer are not synchronized.
+
+  Remote-control:
+
+
 Webots 7.1.2
 
 Released on March 11th, 2013 (revision 13812) 

--- a/resources/projects/robots/darwin-op/plugins/robot_windows/darwin-op_window/Transfer.cpp
+++ b/resources/projects/robots/darwin-op/plugins/robot_windows/darwin-op_window/Transfer.cpp
@@ -516,7 +516,7 @@ void * Transfer::thread_controller(void *param) {
   emit instance->updateStatusSignal("Status : Compiling controller (6/7)"); 
   QString makeClean = QString("make -C /darwin/Linux/project/webots/controllers/") + controller + QString(" -f Makefile.darwin-op clean");
   instance->ExecuteSSHCommand((char*)makeClean.toStdString().c_str());
-  instance->ExecuteSSHCommand((char*)QString("find /darwin/Linux/project/webots/controllers/* -exec touch {} \\;").toStdString().c_str()); // time of all files is updated with the time of the robot (in order to avoid problems if time of the robot and computer are not synchronized)
+  instance->ExecuteSSHCommand("find /darwin/Linux/project/webots/controllers/* -exec touch {} \\;"); // time of all files is updated with the time of the robot (in order to avoid problems if time of the robot and computer are not synchronized)
   instance->WaitEndSSHCommand();
   QString makeController = QString("make -C /darwin/Linux/project/webots/controllers/") + controller + QString(" -f Makefile.darwin-op");
   instance->ExecuteSSHCommand((char*)makeController.toStdString().c_str());

--- a/resources/projects/robots/darwin-op/plugins/robot_windows/darwin-op_window/Transfer.cpp
+++ b/resources/projects/robots/darwin-op/plugins/robot_windows/darwin-op_window/Transfer.cpp
@@ -516,6 +516,8 @@ void * Transfer::thread_controller(void *param) {
   emit instance->updateStatusSignal("Status : Compiling controller (6/7)"); 
   QString makeClean = QString("make -C /darwin/Linux/project/webots/controllers/") + controller + QString(" -f Makefile.darwin-op clean");
   instance->ExecuteSSHCommand((char*)makeClean.toStdString().c_str());
+  instance->ExecuteSSHCommand((char*)QString("find /darwin/Linux/project/webots/controllers/* -exec touch {} \\;").toStdString().c_str()); // time of all files is updated with the time of the robot (in order to avoid problems if time of the robot and computer are not synchronized)
+  instance->WaitEndSSHCommand();
   QString makeController = QString("make -C /darwin/Linux/project/webots/controllers/") + controller + QString(" -f Makefile.darwin-op");
   instance->ExecuteSSHCommand((char*)makeController.toStdString().c_str());
   emit instance->updateProgressSignal(80);


### PR DESCRIPTION
Corrected problem of controllers compilation errors if the time of the robot and of the computer are not synchronized buy updating the time of the controller files before to compile it on the robot.
