### PR TITLE
Added hint in order to show how to add push buttons to the cross-compilation

### DIFF
--- a/resources/projects/robots/darwin-op/transfer/src/Robot.cpp
+++ b/resources/projects/robots/darwin-op/transfer/src/Robot.cpp
@@ -136,6 +136,11 @@ int webots::Robot::step(int ms) {
   ((LED *)mDevices["HeadLed"])->setColor(values[0]);
   ((LED *)mDevices["EyeLed"])->setColor(values[1]);
   LED::setBackPanel(values[2]);
+  
+  // push button state (TODO: check with real robot that the masks are correct)
+  //values[0] = mCM730->m_BulkReadData[::Robot::CM730::ID_CM].ReadWord(::Robot::CM730::P_BUTTON) & 0x1;
+  //values[1] = mCM730->m_BulkReadData[::Robot::CM730::ID_CM].ReadWord(::Robot::CM730::P_BUTTON) & 0x2;
+  //values[2] = mCM730->m_BulkReadData[::Robot::CM730::ID_CM].ReadWord(::Robot::CM730::P_BUTTON) & 0x4;
 
   // -------- Sync Write to actuators --------  //
   const int msgLength = 9; // id + P + Empty + Goal Position (L + H) + Moving speed (L + H) + Torque Limit (L + H)


### PR DESCRIPTION
Since the state of the push buttons should already be in the BulkReadData, 
it is really simple to get them in the robot step.
